### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/jeffreycpierce/ghas-bootcamp/security/code-scanning/5](https://github.com/jeffreycpierce/ghas-bootcamp/security/code-scanning/5)

To fix the problem, we should re-enable CSRF protection by removing or correcting the disabling configuration. In general, this means **not** calling `.csrf().disable()` in the Spring Security configuration. By default, Spring enables CSRF protection, so simply omitting the call to disable it is sufficient for default behavior.

If some endpoints *must* have CSRF disabled (for instance, for truly stateless API endpoints), you can selectively disable it for those, while keeping it enabled globally. However, for this task, the simplest and safest fix is simply to **remove `.csrf().disable()`** from the `configure(HttpSecurity http)` method.

**Steps:**
- In `WebSecurityConfig.java`, remove the call to `.csrf().disable()` from the `http` security chain, specifically between `cors().and()` and `.authorizeRequests()`.
- No additional imports, beans, or methods are necessary, as we're restoring Spring's secure default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
